### PR TITLE
Added support for IDEA 2020.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.gilday"
-version = "1.2.0"
+version = "1.2.1"
 
 repositories {
     mavenCentral()
@@ -26,7 +26,7 @@ java {
 }
 
 intellij {
-    version = "2019.3"
+    version = "2020.1"
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
   </vendor>
 
   <change-notes>
-    Added functionality for Windows.
+    Added functionality for Windows and IDEA 2020.1.
   </change-notes>
 
   <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
Good things first: Jetbrains didn't change anything in their overall code so only a version upgrade is necessary to allow usage in 2020.1

Run Tests on macOS and Windows. Everything is smooth as it should be.

I ran into some warnings during testing. As far as I can tell, no warning causes any problem with the plugin functionality as they are mostly related to IDEA itself. I guess they can be resolved in the future.

@gilday now its your turn :)