### PR TITLE
Migrate plugin to be dynamic

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,9 +32,13 @@
   <application-components>
   </application-components>
   <extensions defaultExtensionNs="com.intellij">
-    <postStartupActivity implementation="com.github.gilday.darkmode.DarkModeSync$MyStartupActivity"/>
     <applicationService serviceImplementation="com.github.gilday.darkmode.DarkModeSync"/>
     <applicationService serviceImplementation="com.github.gilday.darkmode.DarkModeSyncThemes"/>
     <applicationConfigurable instance="com.github.gilday.darkmode.DarkModeConfigurable"/>
   </extensions>
+  <applicationListeners>
+    <listener
+      class="com.github.gilday.darkmode.DarkModeSync$MyLifecycleListener"
+      topic="com.intellij.ide.AppLifecycleListener"/>
+  </applicationListeners>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,11 +30,10 @@
   <depends>com.intellij.modules.platform</depends>
 
   <application-components>
-    <component>
-      <implementation-class>com.github.gilday.darkmode.DarkModeSync</implementation-class>
-    </component>
   </application-components>
   <extensions defaultExtensionNs="com.intellij">
+    <postStartupActivity implementation="com.github.gilday.darkmode.DarkModeSync$MyStartupActivity"/>
+    <applicationService serviceImplementation="com.github.gilday.darkmode.DarkModeSync"/>
     <applicationService serviceImplementation="com.github.gilday.darkmode.DarkModeSyncThemes"/>
     <applicationConfigurable instance="com.github.gilday.darkmode.DarkModeConfigurable"/>
   </extensions>


### PR DESCRIPTION
JetBrains has deprecated components to make IDE startup more performant.
The commit migrates the DarkModeSync component into a service and post
startup activity. Here are some links from JetBrains docs about dynamic
plugin migrations.

- https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/dynamic_plugins.html
- https://jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_components.html